### PR TITLE
[feat] add script for summarize  on all wallets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.log
 __pycache__/
+proxy.json
+devaddress.json
 solutions.csv
 wallets.json
 balances.json

--- a/README.md
+++ b/README.md
@@ -150,6 +150,20 @@ To disable donations, add the `--no-donation` flag:
 python miner.py --no-donation
 ```
 
+### Summarizing NIGHT Balances
+
+To quickly fetch the NIGHT token balances for all wallets stored in your JSON files, use the `sum_night_balance.py` utility:
+
+```
+python sum_night_balance.py --wallets-path wallets.json json --proxy-count 30 --proxy-config proxy.json
+```
+
+- `--wallets-path` accepts one or more files or directories containing wallet JSON definitions.
+- `--proxy-count` limits how many proxy-backed sessions are created simultaneously. For faster results, prepare at least that many proxy entries in `proxy.json`.
+- `--proxy-config` points to the proxy configuration file; if omitted, the script will fall back to direct connections.
+
+> **Tip:** Supplying a rich proxy pool dramatically reduces the chance of hitting rate limits while the script queries the statistics API.
+
 ## Consolidating NIGHT Earnings
 
 You can consolidate all NIGHT earnings to a single wallet using `consolidate.py`. This allows you to save on transaction fees by receiving all NIGHT tokens to a single address (when they are distributed).

--- a/sum_night_balance.py
+++ b/sum_night_balance.py
@@ -1,0 +1,210 @@
+
+import argparse
+import json
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Set, Tuple
+
+import requests
+
+from proxy_config import load_proxy_config
+
+DEFAULT_API_BASE = "https://scavenger.prod.gd.midnighttge.io/"
+
+
+def discover_wallet_files(root: Path) -> Iterable[Path]:
+    if not root.exists():
+        return
+    if root.is_file():
+        yield root
+        return
+
+    for candidate in root.rglob("*.json"):
+        if candidate.is_file():
+            yield candidate
+
+
+def extract_addresses_from_json(path: Path) -> Set[str]:
+    try:
+        with path.open("r", encoding="utf-8") as handler:
+            data = json.load(handler)
+    except (OSError, json.JSONDecodeError):
+        return set()
+
+    addresses: Set[str] = set()
+
+    def _walk(node):
+        if isinstance(node, dict):
+            address = node.get("address")
+            if isinstance(address, str) and address.startswith("addr"):
+                addresses.add(address)
+            for value in node.values():
+                _walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    _walk(data)
+    return addresses
+
+
+def fetch_wallet_statistics(session: requests.Session, wallet_address: str, api_base: str) -> Optional[Tuple[float, dict]]:
+    url = f"{api_base.rstrip('/')}/statistics/{wallet_address}"
+    try:
+        response = session.get(url, timeout=8)
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:  # noqa: BLE001
+        print(f"[WARN] Failed to fetch statistics for {wallet_address}: {exc}")
+        return None
+
+    local_stats = payload.get("local", {})
+    night_raw = local_stats.get("night_allocation", 0)
+    try:
+        night_tokens = float(night_raw) / 1_000_000.0
+    except Exception:  # noqa: BLE001
+        night_tokens = 0.0
+
+    return night_tokens, payload
+
+
+def mask_wallet_address(address: str, visible: int = 6) -> str:
+    if len(address) <= visible * 2:
+        return address
+    return f"{address[:visible]}...{address[-visible:]}"
+
+
+def create_sessions(proxy_config_path: str, desired_workers: int) -> Tuple[Tuple[requests.Session, str], ...]:
+    proxies = load_proxy_config(proxy_config_path)
+
+    sessions: list[Tuple[requests.Session, str]] = []
+
+    if proxies:
+        for entry in proxies[:desired_workers]:
+            session = requests.Session()
+            session.trust_env = False
+            session.proxies.update(entry["proxies"])
+            if entry["auth_header"]:
+                session.headers["Proxy-Authorization"] = entry["auth_header"]
+            display = entry["display"]
+            sessions.append((session, display))
+        print(f"Using {len(sessions)} proxy-backed session(s) (configured: {len(proxies)}).")
+    else:
+        for idx in range(desired_workers):
+            session = requests.Session()
+            session.trust_env = False
+            sessions.append((session, f"direct#{idx + 1}"))
+        print(f"Using {len(sessions)} direct session(s) without proxy.")
+
+    return tuple(sessions)
+
+
+def process_chunk(session: requests.Session, label: str, chunk: Iterable[str], api_base: str) -> Dict[str, float]:
+    results: Dict[str, float] = {}
+    for wallet_address in chunk:
+        result = fetch_wallet_statistics(session, wallet_address, api_base)
+        if result is None:
+            continue
+        night_tokens, _payload = result
+        results[wallet_address] = night_tokens
+    return results
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Summarize NIGHT token balance for wallets described in JSON files."
+    )
+    parser.add_argument(
+        "--wallets-path",
+        nargs="+",
+        default=["wallets.json"],
+        help="Wallet JSON file(s) or directories (space-separated). Example: --wallets-path wallets.json json/",
+    )
+    parser.add_argument(
+        "--api-base",
+        default=DEFAULT_API_BASE,
+        help=f"Statistics API base URL (default: {DEFAULT_API_BASE})",
+    )
+    parser.add_argument(
+        "--proxy-config",
+        default="proxy.json",
+        help="Path to proxy configuration file (default: proxy.json)",
+    )
+    parser.add_argument(
+        "--proxy-count",
+        type=int,
+        default=16,
+        help="Maximum number of concurrent proxy sessions (default: 16)",
+    )
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    wallet_roots = [Path(entry).resolve() for entry in args.wallets_path]
+    wallet_files = {candidate for root in wallet_roots for candidate in discover_wallet_files(root)}
+
+    if not wallet_files:
+        joined_sources = ", ".join(str(root) for root in wallet_roots)
+        print(f"No wallet JSON files found at: {joined_sources}")
+        return 1
+
+    addresses: Set[str] = set()
+    for file_path in sorted(wallet_files):
+        addresses |= extract_addresses_from_json(file_path)
+
+    if not addresses:
+        print("No wallet addresses discovered.")
+        return 1
+
+    print(f"Discovered {len(addresses)} unique wallet addresses from {len(wallet_files)} file(s).")
+
+    sorted_addresses = sorted(addresses)
+    session_target = max(1, min(args.proxy_count, len(sorted_addresses)))
+
+    sessions = create_sessions(args.proxy_config, session_target)
+
+    try:
+        chunks: list[Tuple[requests.Session, str, list[str]]] = []
+        session_count = len(sessions)
+        for index, (session, label) in enumerate(sessions):
+            assigned = sorted_addresses[index::session_count]
+            if assigned:
+                chunks.append((session, label, assigned))
+
+        per_wallet: dict[str, float] = {}
+
+        with ThreadPoolExecutor(max_workers=len(chunks) or 1) as executor:
+            futures = [
+                executor.submit(process_chunk, session, label, chunk, args.api_base)
+                for session, label, chunk in chunks
+            ]
+
+            for future in futures:
+                chunk_result = future.result()
+                per_wallet.update(chunk_result)
+
+        total_night = 0.0
+        for address in sorted(per_wallet.keys()):
+            night_tokens = per_wallet[address]
+            masked_address = mask_wallet_address(address)
+            total_night += night_tokens
+            print(f"{masked_address}: {night_tokens:.6f} NIGHT")
+
+        print("-" * 60)
+        print(f"Total NIGHT across {len(per_wallet)} wallet(s): {total_night:.6f}")
+
+        missing = addresses - per_wallet.keys()
+        if missing:
+            print(f"WARNING: Failed to fetch statistics for {len(missing)} wallet(s).")
+
+        return 0 if per_wallet else 2
+
+    finally:
+        for session, _label in sessions:
+            session.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+


### PR DESCRIPTION
## What's New

- `sum_night_balance.py`: quickly aggregates NIGHT balances across all specified wallets, with parallel requests via proxies (`--proxy-count`, `--proxy-config`).
- Address privacy: the script now masks wallet addresses in its output (showing only leading and trailing characters).
- Documentation (`README.md`) updated with usage guidance and proxy recommendations.

## Testing

https://github.com/user-attachments/assets/c49bdc01-c60c-4080-b560-9f089c84a21b


