### PR TITLE
fix activate venv for windows powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ git clone https://github.com/djeanql/MidnightMiner && cd MidnightMiner
      ```bash
      .\venv\Scripts\Activate.ps1
      ```
-	 *
 
 3. **Install required dependencies**:
    ```bash


### PR DESCRIPTION
This shows both windows options, cmd+powershell
(users also may need to "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser" before activating venv)