### PR TITLE
clean up powershell instructions and remove unused ")"

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,17 @@ git clone https://github.com/djeanql/MidnightMiner && cd MidnightMiner
    - On Windows (CMD):
      ```bash
      venv\Scripts\activate
+	 ```
    
-   - On Windows Powershell: (may need to escalate permission: Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser)
+   - On Windows Powershell:
      ```bash
      .\venv\Scripts\Activate.ps1
      ```
+	 *Note: if you are running running powershell as administrator, you will get an error about permission to run scripts and will 
+	 need to escalate permission*: 
+	 ```bash
+	 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+	 ```
 
 3. **Install required dependencies**:
    ```bash

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ git clone https://github.com/djeanql/MidnightMiner && cd MidnightMiner
      ```bash
      .\venv\Scripts\Activate.ps1
      ```
-	 *Note: if you are running running powershell as administrator, you will get an error about permission to run scripts and will 
+	 *Note: if you are NOT running running powershell as administrator, you will get an error about permission to run scripts and will 
 	 need to escalate permission*: 
 	 ```bash
 	 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser


### PR DESCRIPTION
left accidental ")" at the end of permission escalation for powershell instructions in my previous commit. this commit clarifies them a bit better, removes that extra ")", closes bash on the previous instructions, and fixes the appearance in general.

cheers,
thanks for this awesome miner! 